### PR TITLE
Making TLS configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,7 +22,7 @@ var (
 // Client - structure for the redis client
 type Client struct {
 	client RedisClienter
-	ttl time.Duration
+	ttl    time.Duration
 }
 
 // Config - config options for the redis client
@@ -31,6 +31,7 @@ type Config struct {
 	Password string
 	Database int
 	TTL      time.Duration
+	TLS      *tls.Config
 }
 
 // NewClient - returns new redis client with provided config options
@@ -49,12 +50,10 @@ func NewClient(c Config) (*Client, error) {
 
 	return &Client{
 		client: redis.NewClient(&redis.Options{
-			Addr:     c.Addr,
-			Password: c.Password,
-			DB:       c.Database,
-			TLSConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+			Addr:      c.Addr,
+			Password:  c.Password,
+			DB:        c.Database,
+			TLSConfig: c.TLS,
 		}),
 		ttl: c.TTL,
 	}, nil


### PR DESCRIPTION
Made the TLS options configurable so they can be modified by dp-sessions-api.
This will allow developers to run redis locally by not providing TLS options.